### PR TITLE
Updated hungarian translation

### DIFF
--- a/po/hu.po
+++ b/po/hu.po
@@ -405,7 +405,7 @@ msgstr "Elindítás"
 
 #. txt_nonfree
 msgid "Start (non-free drivers)"
-msgstr "Elindítás (zárt meghajtóval)"
+msgstr "Elindítás (zárt illesztőprogramokkal)"
 
 #. txt_hdt
 msgid "Hardware Detection Tool"


### PR DESCRIPTION
"zárt meghajtóval" meant "with a closed drive", which is far from clear. New translation is a bit longer, but I tested it and it fits.